### PR TITLE
feat(infra): Terraformリモートステート(S3+DynamoDB)を導入しdev環境に適用

### DIFF
--- a/bootstrap-state/.terraform.lock.hcl
+++ b/bootstrap-state/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.60"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/bootstrap-state/main.tf
+++ b/bootstrap-state/main.tf
@@ -1,0 +1,67 @@
+data "aws_caller_identity" "current" {}
+
+locals {
+  bucket_name = lower(format("%s-%s-tfstate-%s-%s",
+    var.project, var.env, data.aws_caller_identity.current.account_id,var.aws_region
+  ))
+  table_name = "${var.project}-tf-locks"
+}
+
+resource "aws_s3_bucket" "tf_state" {
+  bucket = "${var.project}-tf-${var.env}-${data.aws_caller_identity.current.account_id}-${var.aws_region}"
+}
+
+resource "aws_s3_bucket_versioning" "v" {
+  bucket = aws_s3_bucket.tf_state.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "sse" {
+  bucket = aws_s3_bucket.tf_state.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "pab" {
+  bucket = aws_s3_bucket.tf_state.id
+  block_public_acls = true
+  block_public_policy = true
+  ignore_public_acls = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_policy" "tls_only" {
+  bucket = aws_s3_bucket.tf_state.id
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Sid = "DenyInsecureTransport",Effect = "Deny", Principal = "*",
+      Action = "s3:*"
+      Resource = [aws_s3_bucket.tf_state.arn, "${aws_s3_bucket.tf_state.arn}/*"],
+      Condition = { Bool ={ "aws:SecureTransport" = "false" } }
+    }]
+  })
+}
+
+resource "aws_dynamodb_table" "tf_locks" {
+  name = local.table_name
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key = "LockID"
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+}
+
+output "bucket_name" {
+  value = aws_s3_bucket.tf_state.bucket
+}
+
+output "dynamodb_table_name" {
+  value = aws_dynamodb_table.tf_locks.name
+}

--- a/bootstrap-state/variables.tf
+++ b/bootstrap-state/variables.tf
@@ -1,0 +1,14 @@
+variable "project" {
+  type = string
+  default = "cloudnative-observability"
+}
+
+variable "env" {
+  type = string
+  default = "global"
+}
+
+variable "aws_region" {
+  type = string
+  default = "ap-northeast-1"
+}

--- a/bootstrap-state/versions.tf
+++ b/bootstrap-state/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.9.0"
+  required_providers {
+    aws = { source = "hashicorp/aws", version = "~>5.60"}
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+  default_tags {
+    tags = {
+      Project = var.project
+      Environment = var.env
+      ManagedBy = "Terraform"
+      Component = "bootstrap-state"
+    }
+  }
+}

--- a/environments/dev/.terraform.lock.hcl
+++ b/environments/dev/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.6.2"
+  constraints = "~> 5.6.0"
+  hashes = [
+    "h1:lH9eN+oozDX4z/TvhoXg++5MIE6MQznSW5sXvqzXAVQ=",
+    "zh:25322d7e1f0054550357d5a03fe29168cc179421e5dcf44b28c25a99d8d6e4e7",
+    "zh:394aa5bff70003e76d1d33ef4fe37c4826918577cf339d35e56ae84d01e86765",
+    "zh:485b288bf95b5d3014903e386e8ee2d1182e507f746bc988458b9711c7df7171",
+    "zh:48cf69750681337d64df7e402116a6753a40b6702c49fc9232ff6621947d85af",
+    "zh:6ab11d052d681b5157e261b9dd9167482acffe2018fffd1204575e9bf6a08522",
+    "zh:882f22d0e6c16cd5a5f01a0ae817b1e75e928667d21d986b93a4ee74fa62c067",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ac3403e3ab5c10869b23626467b919e3f010e7cae6e0acf8515e0cefab0dbff0",
+    "zh:b959a425c9be83838895e8626037656bf5db81397ad0078595d3b72fd1b816bc",
+    "zh:bf390951f21a5fe6b96b206c5496fda4d8b95823bd00d1c03a4a53dd215d882a",
+    "zh:c3534972986cd68a421359f07ab86631ffa8731606936276fce18ec8ae9045f4",
+    "zh:d4cf29d67ead2c5feb999c2882e5365bd4d04c115e98fb1639b747b682507fea",
+    "zh:dea669eea5bca9b57dae2975ec783d577d58a39eec769d1c9bd7fc4d50f241d0",
+    "zh:e7a82063d01eb2be3fd192afbad910150fe8054731db20c1b22c714d9391dbe5",
+    "zh:fdbbf96948e96dfed614ea4daa4f1706859122a3f978c42c37db8727cb55c94f",
+  ]
+}

--- a/environments/dev/backend.tf
+++ b/environments/dev/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket = "cloudnative-observability-tf-global-318839415844-ap-northeast-1"
+    key = "dev/terraform.tfstate"
+    region = "ap-northeast-1"
+    dynamodb_table = "cloudnative-observability-tf-locks"
+    encrypt = true
+  }
+}

--- a/environments/dev/providers.tf
+++ b/environments/dev/providers.tf
@@ -1,0 +1,11 @@
+provider "aws" {
+  region = var.aws_region
+  default_tags {
+    tags = {
+      Project = var.project
+      Environment = var.env
+      ManagedBy = "Terraform"
+      Component = "infra"
+    }
+  }
+}

--- a/environments/dev/variables.tf
+++ b/environments/dev/variables.tf
@@ -1,0 +1,14 @@
+variable "aws_region" {
+  type = string
+  default = "ap-northeast-1"
+}
+
+variable "env" {
+  type = string
+  default = "dev"
+}
+
+variable "project" {
+  type = string
+  default = "cloudnative-observability"
+}

--- a/environments/dev/versions.tf
+++ b/environments/dev/versions.tf
@@ -1,0 +1,6 @@
+terraform {
+  required_version = ">= 1.9.0"
+  required_providers {
+    aws = { source = "hashicorp/aws",version = "~> 5.6.0" }
+  }
+}


### PR DESCRIPTION
## 概要
- Terraformのリモートステート管理を導入(背景:今後のVPC/EKS構築に備えてstateをS3+DynamoDBで管理するため)

## 動作確認
- 実行コマンド:
```bash
cd bootstrap-state
terraform apply -auto-approve

cd ../environments/dev
terraform init -reconfigure
terraform plan
```

- 期待結果
  - S3バケットにdev/terraform.tfstateが生成される
  - DynamoDB テーブル cloudnative-observability-tf-locks が存在し、state lock を管理できる
  - terraform plan が差分なしで実行可能