### PR TITLE
feat(eks-cluster):EKSクラスタ、aws-authグループの追加

### DIFF
--- a/environments/dev/.terraform.lock.hcl
+++ b/environments/dev/.terraform.lock.hcl
@@ -23,3 +23,103 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/cloudinit" {
+  version     = "2.3.7"
+  constraints = ">= 2.0.0"
+  hashes = [
+    "h1:M9TpQxKAE/hyOwytdX9MUNZw30HoD/OXqYIug5fkqH8=",
+    "zh:06f1c54e919425c3139f8aeb8fcf9bceca7e560d48c9f0c1e3bb0a8ad9d9da1e",
+    "zh:0e1e4cf6fd98b019e764c28586a386dc136129fef50af8c7165a067e7e4a31d5",
+    "zh:1871f4337c7c57287d4d67396f633d224b8938708b772abfc664d1f80bd67edd",
+    "zh:2b9269d91b742a71b2248439d5e9824f0447e6d261bfb86a8a88528609b136d1",
+    "zh:3d8ae039af21426072c66d6a59a467d51f2d9189b8198616888c1b7fc42addc7",
+    "zh:3ef4e2db5bcf3e2d915921adced43929214e0946a6fb11793085d9a48995ae01",
+    "zh:42ae54381147437c83cbb8790cc68935d71b6357728a154109d3220b1beb4dc9",
+    "zh:4496b362605ae4cbc9ef7995d102351e2fe311897586ffc7a4a262ccca0c782a",
+    "zh:652a2401257a12706d32842f66dac05a735693abcb3e6517d6b5e2573729ba13",
+    "zh:7406c30806f5979eaed5f50c548eced2ea18ea121e01801d2f0d4d87a04f6a14",
+    "zh:7848429fd5a5bcf35f6fee8487df0fb64b09ec071330f3ff240c0343fe2a5224",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "2.38.0"
+  constraints = ">= 2.20.0, ~> 2.32"
+  hashes = [
+    "h1:soK8Lt0SZ6dB+HsypFRDzuX/npqlMU6M0fvyaR1yW0k=",
+    "zh:0af928d776eb269b192dc0ea0f8a3f0f5ec117224cd644bdacdc682300f84ba0",
+    "zh:1be998e67206f7cfc4ffe77c01a09ac91ce725de0abaec9030b22c0a832af44f",
+    "zh:326803fe5946023687d603f6f1bab24de7af3d426b01d20e51d4e6fbe4e7ec1b",
+    "zh:4a99ec8d91193af961de1abb1f824be73df07489301d62e6141a656b3ebfff12",
+    "zh:5136e51765d6a0b9e4dbcc3b38821e9736bd2136cf15e9aac11668f22db117d2",
+    "zh:63fab47349852d7802fb032e4f2b6a101ee1ce34b62557a9ad0f0f0f5b6ecfdc",
+    "zh:924fb0257e2d03e03e2bfe9c7b99aa73c195b1f19412ca09960001bee3c50d15",
+    "zh:b63a0be5e233f8f6727c56bed3b61eb9456ca7a8bb29539fba0837f1badf1396",
+    "zh:d39861aa21077f1bc899bc53e7233262e530ba8a3a2d737449b100daeb303e4d",
+    "zh:de0805e10ebe4c83ce3b728a67f6b0f9d18be32b25146aa89116634df5145ad4",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:faf23e45f0090eef8ba28a8aac7ec5d4fdf11a36c40a8d286304567d71c1e7db",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.2.4"
+  constraints = ">= 3.0.0"
+  hashes = [
+    "h1:L5V05xwp/Gto1leRryuesxjMfgZwjb7oool4WS1UEFQ=",
+    "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:795c897119ff082133150121d39ff26cb5f89a730a2c8c26f3a9c1abf81a9c43",
+    "zh:7b9c7b16f118fbc2b05a983817b8ce2f86df125857966ad356353baf4bff5c0a",
+    "zh:85e33ab43e0e1726e5f97a874b8e24820b6565ff8076523cc2922ba671492991",
+    "zh:9d32ac3619cfc93eb3c4f423492a8e0f79db05fec58e449dee9b2d5873d5f69f",
+    "zh:9e15c3c9dd8e0d1e3731841d44c34571b6c97f5b95e8296a45318b94e5287a6e",
+    "zh:b4c2ab35d1b7696c30b64bf2c0f3a62329107bd1a9121ce70683dec58af19615",
+    "zh:c43723e8cc65bcdf5e0c92581dcbbdcbdcf18b8d2037406a5f2033b1e22de442",
+    "zh:ceb5495d9c31bfb299d246ab333f08c7fb0d67a4f82681fbf47f2a21c3e11ab5",
+    "zh:e171026b3659305c558d9804062762d168f50ba02b88b231d20ec99578a6233f",
+    "zh:ed0fe2acdb61330b01841fa790be00ec6beaac91d41f311fb8254f74eb6a711f",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/time" {
+  version     = "0.13.1"
+  constraints = ">= 0.9.0"
+  hashes = [
+    "h1:ZT5ppCNIModqk3iOkVt5my8b8yBHmDpl663JtXAIRqM=",
+    "zh:02cb9aab1002f0f2a94a4f85acec8893297dc75915f7404c165983f720a54b74",
+    "zh:04429b2b31a492d19e5ecf999b116d396dac0b24bba0d0fb19ecaefe193fdb8f",
+    "zh:26f8e51bb7c275c404ba6028c1b530312066009194db721a8427a7bc5cdbc83a",
+    "zh:772ff8dbdbef968651ab3ae76d04afd355c32f8a868d03244db3f8496e462690",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:898db5d2b6bd6ca5457dccb52eedbc7c5b1a71e4a4658381bcbb38cedbbda328",
+    "zh:8de913bf09a3fa7bedc29fec18c47c571d0c7a3d0644322c46f3aa648cf30cd8",
+    "zh:9402102c86a87bdfe7e501ffbb9c685c32bbcefcfcf897fd7d53df414c36877b",
+    "zh:b18b9bb1726bb8cfbefc0a29cf3657c82578001f514bcf4c079839b6776c47f0",
+    "zh:b9d31fdc4faecb909d7c5ce41d2479dd0536862a963df434be4b16e8e4edc94d",
+    "zh:c951e9f39cca3446c060bd63933ebb89cedde9523904813973fbc3d11863ba75",
+    "zh:e5b773c0d07e962291be0e9b413c7a22c044b8c7b58c76e8aa91d1659990dfb5",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "4.1.0"
+  constraints = ">= 3.0.0"
+  hashes = [
+    "h1:zEv9tY1KR5vaLSyp2lkrucNJ+Vq3c+sTFK9GyQGLtFs=",
+    "zh:14c35d89307988c835a7f8e26f1b83ce771e5f9b41e407f86a644c0152089ac2",
+    "zh:2fb9fe7a8b5afdbd3e903acb6776ef1be3f2e587fb236a8c60f11a9fa165faa8",
+    "zh:35808142ef850c0c60dd93dc06b95c747720ed2c40c89031781165f0c2baa2fc",
+    "zh:35b5dc95bc75f0b3b9c5ce54d4d7600c1ebc96fbb8dfca174536e8bf103c8cdc",
+    "zh:38aa27c6a6c98f1712aa5cc30011884dc4b128b4073a4a27883374bfa3ec9fac",
+    "zh:51fb247e3a2e88f0047cb97bb9df7c228254a3b3021c5534e4563b4007e6f882",
+    "zh:62b981ce491e38d892ba6364d1d0cdaadcee37cc218590e07b310b1dfa34be2d",
+    "zh:bc8e47efc611924a79f947ce072a9ad698f311d4a60d0b4dfff6758c912b7298",
+    "zh:c149508bd131765d1bc085c75a870abb314ff5a6d7f5ac1035a8892d686b6297",
+    "zh:d38d40783503d278b63858978d40e07ac48123a2925e1a6b47e62179c046f87a",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fb07f708e3316615f6d218cec198504984c0ce7000b9f1eebff7516e384f4b54",
+  ]
+}

--- a/environments/dev/eks/main.tf
+++ b/environments/dev/eks/main.tf
@@ -1,0 +1,62 @@
+locals {
+  name = "${var.project}-${var.env}"
+}
+
+module "eks" {
+  source = "terraform-aws-modules/eks/aws"
+  version = "~> 20.0"
+
+  # Core
+  cluster_name = var.cluster_name
+  cluster_version = var.cluster_version
+
+  vpc_id = var.vpc_id
+  subnet_ids = var.private_subnets
+
+  # endpoint access
+  cluster_endpoint_public_access = var.endpoint_public_access
+  cluster_endpoint_private_access = var.endpoint_private_access
+
+  # IRSA
+  enable_irsa = true
+
+  # Managed node group (t3.medium, min=1,desired=2)
+  eks_managed_node_groups = {
+    default = {
+      instance_types = var.node_instance_types
+      capacity_type = "ON_DEMAND"
+
+      min_size = var.node_min_size
+      desired_size = var.node_desired_size
+      max_size = var.node_max_size
+      disk_size = var.node_disk_size
+
+      subnet_ids = var.private_subnets
+      labels = { "workload" = "general" }
+    }
+  }
+
+  tags = merge(
+    {
+      "Project" = var.project
+      "Env" = var.env
+    },
+    var.tags
+  )
+}
+
+module "eks_aws_auth" {
+  source = "terraform-aws-modules/eks/aws//modules/aws-auth"
+  version = "~> 20.0"
+
+  manage_aws_auth_configmap = true
+  aws_auth_roles            = var.aws_auth_roles
+  aws_auth_users            = var.aws_auth_users
+  aws_auth_accounts         = var.aws_auth_accounts
+
+  providers = {
+    kubernetes = kubernetes
+  }
+
+  depends_on = [ module.eks ]
+}

--- a/environments/dev/eks/outputs.tf
+++ b/environments/dev/eks/outputs.tf
@@ -1,0 +1,29 @@
+output "cluster_name" {
+  description = "EKS cluster name"
+  value = module.eks.cluster_name
+}
+
+output "cluster_arn" {
+  description = "EKS cluster ARN"
+  value = module.eks.cluster_arn
+}
+
+output "cluster_endpoint" {
+  description = "EKS API server endpoint"
+  value = module.eks.cluster_endpoint
+}
+
+output "cluster_certificate_authority_data" {
+  description = "Base64-encoded cluster CA"
+  value = module.eks.cluster_certificate_authority_data
+}
+
+output "oidc_provider_arn" {
+  description = "OIDC provider ARN for IRSA"
+  value = module.eks.oidc_provider_arn
+}
+
+output "managed_node_group_names" {
+  description = "EKS managed node group names"
+  value = keys(module.eks.eks_managed_node_groups)
+  }

--- a/environments/dev/eks/required_providers.tf
+++ b/environments/dev/eks/required_providers.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
+}

--- a/environments/dev/eks/variables.tf
+++ b/environments/dev/eks/variables.tf
@@ -1,0 +1,110 @@
+variable "project" {
+  description = "Project name tag"
+  type = string
+}
+
+variable "env" {
+  description = "Environment name tag (e.g. dev)"
+  type = string
+}
+
+variable "cluster_name" {
+  description = "EKS cluster name"
+  type = string
+}
+
+variable "cluster_version" {
+  description = "EKS version (e.g. 1.29)"
+  type = string
+  default = "1.29"
+}
+
+variable "vpc_id" {
+  description = "VPC ID where EKS will be created"
+  type = string
+}
+
+variable "private_subnets" {
+  description = "Private subnet IDs for worker nodes"
+  type = list(string)
+}
+
+variable "public_subnets" {
+  description = "Public subnet IDs (optional, for LB etc.)"
+  type = list(string)
+  default = []
+}
+
+variable "endpoint_public_access" {
+  description = "Enable public API endpoint"
+  type = bool
+  default = true
+}
+
+variable "endpoint_private_access" {
+  description = "Enable private API endpoint"
+  type = bool
+  default = true
+}
+
+variable "node_instance_types" {
+  description = "Instance types for the default managed node group"
+  type = list(string)
+  default = [ "t3.medium" ]
+}
+
+variable "node_desired_size" {
+  description = "Desired size for the default node group"
+  type = number
+  default = 2
+}
+
+variable "node_min_size" {
+  description = "Min size for the default node group"
+  type = number
+  default = 1
+}
+
+variable "node_max_size" {
+  description = "Max size for the default node group"
+  type = number
+  default = 3
+}
+
+variable "node_disk_size" {
+  description = "Node root volume size (GiB)"
+  type = number
+  default = 20
+}
+
+variable "aws_auth_roles" {
+  description = "aws-auth role mappings"
+  type = list(object({
+    rolearn = string
+    username = string
+    groups = list(string)
+  }))
+  default = []
+}
+
+variable "aws_auth_users" {
+  description = "aws-auth user mappings"
+  type = list(object({
+    userarn = string
+    username = string
+    groups = list(string)
+  }))
+  default = []
+}
+
+variable "aws_auth_accounts" {
+  description = "aws-auth account IDs"
+  type = list(string)
+  default = []
+}
+
+variable "tags" {
+  description = "Extra tags"
+  type = map(string)
+  default = {}
+}

--- a/environments/dev/kube_provider.tf
+++ b/environments/dev/kube_provider.tf
@@ -1,0 +1,14 @@
+data "aws_eks_cluster" "this" {
+  name = module.eks.cluster_name
+}
+
+data "aws_eks_cluster_auth" "this" {
+  name = module.eks.cluster_name
+}
+
+provider "kubernetes" {
+  alias = "eks"
+  host = data.aws_eks_cluster.this.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority[0].data)
+  token = data.aws_eks_cluster_auth.this.token
+}

--- a/environments/dev/main.eks.tf
+++ b/environments/dev/main.eks.tf
@@ -1,0 +1,24 @@
+module "eks" {
+  source = "./eks"
+
+  project = var.project
+  env = var.env
+
+  cluster_name = "grpc-observability-cluster"
+  cluster_version = "1.29"
+
+  vpc_id = module.network.vpc_id
+  private_subnets = module.network.private_subnets
+  public_subnets = module.network.public_subnets
+
+  endpoint_public_access = true
+  endpoint_private_access = true
+
+  aws_auth_roles = []
+  aws_auth_users = []
+  aws_auth_accounts = []
+
+  providers = {
+    kubernetes = kubernetes.eks
+  }
+}

--- a/environments/dev/network/versions.tf
+++ b/environments/dev/network/versions.tf
@@ -1,9 +1,0 @@
-terraform {
-  required_version = ">= 1.9.0"
-  required_providers {
-    aws = {
-      source = "hashicorp/aws"
-      version = "~> 5.60"
-    }
-  }
-}

--- a/environments/dev/versions.tf
+++ b/environments/dev/versions.tf
@@ -1,10 +1,14 @@
 terraform {
-  required_version = ">= 1.9.0"
+  required_version = "~> 1.9"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
       version = ">= 5.79.0, < 6.0.0"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+      version = "~> 2.32"
     }
   }
 }


### PR DESCRIPTION
## 概要
- EKSクラスタ(1.29)をTerraform管理で構築
- IRSA(OIDC Provider)を有効化し、今後のServiceAccount/IAMロール連携に備える
- aws-authをTerraform管理に切り替え
- 目的：infraリポジトリの基盤としてEKSクラスタを作成し、今後実装する内容(IRSA,Argo CD)への準備

## 変更点
- `environments/dev/eks/` 以下に EKS モジュールを追加
  - variables/main/outputsを作成
  - EKS v20モジュールを利用しIRSA/Managed Node Group を設定
- aws-auth をサブモジュール `modules/aws-auth` で管理
- Kubernetes プロバイダ（alias: eks）をルートに追加し、aws-auth に渡す
- outputs 修正 (`eks_managed_node_groups` → `keys()` で NG 名一覧を出力)

## 動作確認

1. `terraform init -upgrade`
2. `terraform plan` で差分が正しく出力されることを確認
3. `terraform apply` でクラスタを構築
4. `aws eks update-kubeconfig --name grpc-observability-cluster --region ap-northeast-1`
5. `kubectl get nodes` でノードが Ready になることを確認