### PR TITLE
feat(iam-irsa):IRSAモジュールの追加

### DIFF
--- a/environments/dev/iam_irsa.tf
+++ b/environments/dev/iam_irsa.tf
@@ -1,0 +1,118 @@
+locals {
+  oidc_provider_arn = module.eks.oidc_provider_arn
+  oidc_issuer_url = module.eks.cluster_oidc_issuer_url
+
+  tags = {
+    Project = "cloudnative-observability"
+    Env = "dev"
+  }
+}
+
+# Argo CD:s3読取(helmリポジトリ)
+variable "argocd_s3_bucket_name" {
+  type = string
+  description = "Argo CDがHelm Chartを取得するS3バケット名(read-only)"
+}
+
+data "aws_iam_policy_document" "argocd_s3_ro" {
+  statement {
+    sid = "ListBucket"
+    effect = "Allow"
+    actions = [ "s3:ListBucket" ]
+    resources = [
+      "arn:aws:s3:::${var.argocd_s3_bucket_name}"
+    ]
+  }
+  statement {
+    sid = "GetObjects"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:GetObjectVersion"
+     ]
+     resources = [
+      "arn:aws:s3:::${var.argocd_s3_bucket_name}/*"
+     ]
+  }
+}
+
+module "irsa_argocd" {
+  source = "../../modules/irsa-role"
+  name = "argocd-app-controller"
+  namespace = "argocd"
+  service_account = "argocd-application-controller"
+  oidc_provider_arn = local.oidc_provider_arn
+  oidc_issuer_url = local.oidc_issuer_url
+  policy_json = data.aws_iam_policy_document.argocd_s3_ro.json
+  policy_arns = []
+  create_namespace = false
+  create_service_account = false
+  tags = local.tags
+}
+
+variable "sealed_secrets_backup_bucket" {
+  type = string
+  description = "Sealed Secretsの鍵バックアップ用S3バケット"
+}
+
+data "aws_iam_policy_document" "sealed_s3_rw" {
+  statement {
+    sid = "ListBucket"
+    effect = "Allow"
+    actions = ["s3:ListBucket"]
+    resources = [
+      "arn:aws:s3:::${var.sealed_secrets_backup_bucket}"
+    ]
+  }
+  statement {
+    sid = "PutGetObjects"
+    effect = "Allow"
+    actions = [ "s3:GetObject", "s3:PutObject" ]
+    resources = [
+      "arn:aws:s3:::${var.sealed_secrets_backup_bucket}/*"
+    ]
+  }
+}
+
+module "irsa_sealed_secrets" {
+  source = "../../modules/irsa-role"
+  name = "sealed-secrets-controller"
+  namespace = "sealed-secrets"
+  service_account = "sealed-secrets-controller"
+  oidc_provider_arn = local.oidc_provider_arn
+  oidc_issuer_url = local.oidc_issuer_url
+  policy_json = data.aws_iam_policy_document.sealed_s3_rw.json
+  policy_arns = []
+  create_namespace = true
+  create_service_account = true
+  tags = local.tags
+}
+
+# OpenTelemetry Collector: CloudWatch Logs & X-Ray (任意)
+
+variable "otelcloudwatch_log_group_arn" {
+  type = string
+  description = "Otel Collectorが出力するCloudWatch LogsのLogGroup ARN"
+  default = "null"
+}
+
+locals {
+  otel_managed_policies = [
+    "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy",
+    "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
+  ]
+}
+
+module "irsa_otel" {
+  source = "../../modules/irsa-role"
+  name = "otel-collector"
+  namespace = "monitoring"
+  service_account = "otel-collector"
+  oidc_provider_arn = local.oidc_provider_arn
+  oidc_issuer_url = local.oidc_issuer_url
+  policy_json = null
+  policy_arns = local.otel_managed_policies
+  create_namespace = true
+  create_service_account = true
+  tags = local.tags
+}

--- a/environments/dev/variables.irsa.tfvars
+++ b/environments/dev/variables.irsa.tfvars
@@ -1,0 +1,3 @@
+argocd_s3_bucket_name = "cno-dev-argocd-helm-repo"
+sealed_secrets_backup_bucket = "cno-dev-sealed-secrets-backup"
+# otelcloudwatch_log_group_arn = "arn:aws:logs:ap-northeast-1:318839415844:log-group:/aws/eks/cloudnative-observability/*"

--- a/modules/irsa-role/main.tf
+++ b/modules/irsa-role/main.tf
@@ -1,0 +1,75 @@
+locals {
+  issuer_host = replace(var.oidc_issuer_url, "https://", "")
+}
+
+data "aws_iam_policy_document" "trust" {
+  statement {
+    effect = "Allow"
+    actions = [ "sts:AssumeRoleWithWebIdentity" ]
+
+    principals {
+      type = "Federated"
+      identifiers = [ var.oidc_provider_arn ]
+    }
+
+    condition {
+      test = "StringEquals"
+      variable = "${local.issuer_host}:sub"
+      values = [ "system:serviceaccount:${var.namespace}:${var.service_account}" ]
+    }
+
+      condition {
+      test = "StringEquals"
+      variable = "${local.issuer_host}:aud"
+      values = [ "sts.amazonaws.com" ]
+    }
+  }
+}
+
+resource "aws_iam_role" "this" {
+  name = "irsa-${var.name}"
+  assume_role_policy = data.aws_iam_policy_document.trust.json
+  tags = var.tags
+}
+
+resource "aws_iam_policy" "inline" {
+  count = var.policy_json == null ? 0 : 1
+  name = "irsa-${var.name}-inline"
+  description = "Inline policy for ${var.name}"
+  policy = var.policy_json
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "inline_attach" {
+  count = var.policy_json == null ? 0 : 1
+  role = aws_iam_role.this.name
+  policy_arn = aws_iam_policy.inline[0].arn
+}
+
+resource "aws_iam_role_policy_attachment" "managed_attach" {
+  for_each = toset(var.policy_arns)
+  role = aws_iam_role.this.name
+  policy_arn = each.value
+}
+
+resource "kubernetes_namespace" "ns" {
+  count = var.create_namespace ? 1 : 0
+  metadata {
+    name = var.namespace
+  }
+}
+
+resource "kubernetes_service_account" "sa" {
+  count = var.create_service_account ? 1 : 0
+
+  metadata {
+    name = var.service_account
+    namespace = var.namespace
+    annotations = {
+      "eks.amazonaws.com/role-arn" = aws_iam_role.this.arn
+    }
+    labels = {
+      "app.kubernetes.io/managed-by" = "terraform"
+    }
+  }
+}

--- a/modules/irsa-role/outputs.tf
+++ b/modules/irsa-role/outputs.tf
@@ -1,0 +1,7 @@
+output "role_arn" {
+  value = aws_iam_role.this.arn
+}
+
+output "sa_name" {
+  value = var.service_account
+}

--- a/modules/irsa-role/variables.tf
+++ b/modules/irsa-role/variables.tf
@@ -1,0 +1,46 @@
+variable "name" {
+  type = string
+}
+
+variable "namespace" {
+  type = string
+}
+
+variable "service_account" {
+  type = string
+}
+
+variable "oidc_provider_arn" {
+  type = string
+}
+
+variable "oidc_issuer_url" {
+  type = string
+}
+
+variable "policy_json" {
+  type = string
+  description = "(任意)インラインIAMポリシー(JSON)。空なら作成しない"
+  default = null
+}
+
+variable "policy_arns" {
+  type = list(string)
+  description = "(任意)既存のマネージドポリシーARNをアタッチする場合"
+  default = []
+}
+
+variable "create_service_account" {
+  type = bool
+  default = true
+}
+
+variable "create_namespace" {
+  type = bool
+  default = true
+}
+
+variable "tags" {
+  type = map(string)
+  default = {}
+}


### PR DESCRIPTION
## 概要
- EKSのIRSA(OIDC)を用い、ServiceAccount単位で最小権限のIAM Roleを付与するよう設定(再利用モジュール化)
- 後続のArgo CD/Sealed Secrets/OTel Collector導入時にも活用可能にする。

## 変更点
- 追加：modules/irsa-role
  - OIDC信頼ポリシー(sub/audを固定)
  - インライン/既存マネージド両方のポリシー付与に対応
  - Namespace/ServiceAccountをトグルで作成可能(Helmと競合回避可能)
- 追加：environments/dev/iam_irsa.tf
  - argocd/argocd-application-controller → S3 読み取り(argocd_s3_bucket_name)
  - sealed-secrets/sealed-secrets-controller → S3 読み書き（sealed_secrets_backup_bucket）
  - monitoring/otel-collector → CloudWatch Logs & X-Ray
- 追加: environments/dev/variables.irsa.tfvars（環境依存値の外出し）

## 動作確認
```bash
cd environments/dev
terraform fmt && terraform validate
terraform plan  -var-file=variables.irsa.tfvars
terraform apply -var-file=variables.irsa.tfvars
```
