### PR TITLE
feat(argocd-bootstrap):helm経由のArgo CD導入

### DIFF
--- a/environments/dev/.terraform.lock.hcl
+++ b/environments/dev/.terraform.lock.hcl
@@ -44,6 +44,26 @@ provider "registry.terraform.io/hashicorp/cloudinit" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/helm" {
+  version     = "2.17.0"
+  constraints = "~> 2.13"
+  hashes = [
+    "h1:kQMkcPVvHOguOqnxoEU2sm1ND9vCHiT8TvZ2x6v/Rsw=",
+    "zh:06fb4e9932f0afc1904d2279e6e99353c2ddac0d765305ce90519af410706bd4",
+    "zh:104eccfc781fc868da3c7fec4385ad14ed183eb985c96331a1a937ac79c2d1a7",
+    "zh:129345c82359837bb3f0070ce4891ec232697052f7d5ccf61d43d818912cf5f3",
+    "zh:3956187ec239f4045975b35e8c30741f701aa494c386aaa04ebabffe7749f81c",
+    "zh:66a9686d92a6b3ec43de3ca3fde60ef3d89fb76259ed3313ca4eb9bb8c13b7dd",
+    "zh:88644260090aa621e7e8083585c468c8dd5e09a3c01a432fb05da5c4623af940",
+    "zh:a248f650d174a883b32c5b94f9e725f4057e623b00f171936dcdcc840fad0b3e",
+    "zh:aa498c1f1ab93be5c8fbf6d48af51dc6ef0f10b2ea88d67bcb9f02d1d80d3930",
+    "zh:bf01e0f2ec2468c53596e027d376532a2d30feb72b0b5b810334d043109ae32f",
+    "zh:c46fa84cc8388e5ca87eb575a534ebcf68819c5a5724142998b487cb11246654",
+    "zh:d0c0f15ffc115c0965cbfe5c81f18c2e114113e7a1e6829f6bfd879ce5744fbb",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/kubernetes" {
   version     = "2.38.0"
   constraints = ">= 2.20.0, ~> 2.32"

--- a/environments/dev/argocd.tf
+++ b/environments/dev/argocd.tf
@@ -1,0 +1,60 @@
+resource "kubernetes_namespace" "argocd" {
+  provider = kubernetes.eks
+  metadata {
+    name = "argocd"
+    labels = {
+      "pod-security.kubernetes.io/enforce" = "restricted"
+    }
+  }
+}
+
+resource "helm_release" "argocd" {
+  provider = helm.eks
+  name = "argocd"
+  namespace = kubernetes_namespace.argocd.metadata[0].name
+  repository = "https://argoproj.github.io/argo-helm"
+  chart = "argo-cd"
+  version = "8.3.0"
+  create_namespace = false
+  cleanup_on_fail = true
+  timeout = 600
+
+  values = [<<-YAML
+    global: {}
+
+    crds:
+      install: true
+
+    dex:
+      enabled: false
+
+    notifications:
+      enabled: false
+
+    controller:
+      replicas: 1
+
+    repoServer:
+      replicas: 1
+
+    applicationSet:
+      enabled: true
+
+    server:
+      replicas: 1
+      service:
+        type: ClusterIP
+
+    config:
+      params:
+        server.insecure: "true"
+  YAML
+  ]
+}
+output "argocd_namespace" {
+  value = kubernetes_namespace.argocd.metadata[0].name
+}
+
+output "argocd_release_version" {
+  value = helm_release.argocd.version
+}

--- a/environments/dev/eks/outputs.tf
+++ b/environments/dev/eks/outputs.tf
@@ -27,3 +27,11 @@ output "managed_node_group_names" {
   description = "EKS managed node group names"
   value = keys(module.eks.eks_managed_node_groups)
   }
+
+output "cluster_oidc_issuer_url" {
+  value = module.eks.cluster_oidc_issuer_url
+}
+
+output "cluster_oidc_provider_arn" {
+  value = module.eks.oidc_provider_arn
+}

--- a/environments/dev/helm_provider.tf
+++ b/environments/dev/helm_provider.tf
@@ -1,0 +1,8 @@
+provider "helm" {
+  alias = "eks"
+  kubernetes {
+    host = data.aws_eks_cluster.this.endpoint
+    cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority[0].data)
+    token = data.aws_eks_cluster_auth.this.token
+  }
+}

--- a/environments/dev/versions.tf
+++ b/environments/dev/versions.tf
@@ -10,5 +10,9 @@ terraform {
       source = "hashicorp/kubernetes"
       version = "~> 2.32"
     }
+    helm = {
+      source = "hashicorp/helm"
+      version = "~> 2.13"
+    }
   }
 }


### PR DESCRIPTION
## 概要
- Argo CDをEKSクラスタへ導入
- Terraformでargocd Namespaceを作成し、Helm Provider経由でArgo CD Chartをデプロイ

## 変更点
- kube_provider.tf：Kubernetes Provider（alias=eks）を利用
- helm_provider.tf：Helm Provider（alias=eks）を追加
- argocd.tf：
  - Namespace (argocd) 作成
  - Helm Release (argo-cd v8.3.0) を定義
  - 出力（namespace 名、リリースバージョン）を追加
- providers.tf / versions.tf：Helm Provider を required_providers に追加、バージョン統一