### PR TITLE
feat(argocd-appofapps):AppProjectガードレールとapp-of-apps(root Application)をTerraformで追加

### DIFF
--- a/environments/dev/argocd.tf
+++ b/environments/dev/argocd.tf
@@ -9,15 +9,15 @@ resource "kubernetes_namespace" "argocd" {
 }
 
 resource "helm_release" "argocd" {
-  provider = helm.eks
-  name = "argocd"
-  namespace = kubernetes_namespace.argocd.metadata[0].name
-  repository = "https://argoproj.github.io/argo-helm"
-  chart = "argo-cd"
-  version = "8.3.0"
+  provider         = helm.eks
+  name             = "argocd"
+  namespace        = kubernetes_namespace.argocd.metadata[0].name
+  repository       = "https://argoproj.github.io/argo-helm"
+  chart            = "argo-cd"
+  version          = "8.3.0"
   create_namespace = false
-  cleanup_on_fail = true
-  timeout = 600
+  cleanup_on_fail  = true
+  timeout          = 600
 
   values = [<<-YAML
     global: {}

--- a/environments/dev/argocd_appofapps.tf
+++ b/environments/dev/argocd_appofapps.tf
@@ -1,0 +1,87 @@
+locals {
+  default_source_repos = ["https://github.com/${var.repo_owner}/*"]
+  source_repos         = length(var.source_repos_allowlist) > 0 ? var.source_repos_allowlist : local.default_source_repos
+}
+
+resource "kubernetes_manifest" "argocd_project_cno" {
+  manifest = {
+    apiVersion = "argoproj.io/v1alpha1"
+    kind       = "AppProject"
+    metadata = {
+      name      = "cloudnative-observability"
+      namespace = kubernetes_namespace.argocd.metadata[0].name
+      labels = {
+        "app.kubernetes.io/managed-by" = "terraform"
+      }
+    }
+    spec = {
+      description = "Guardrails for cloudnative-observability portfolio"
+      sourceRepos = local.source_repos
+
+      destinations = [
+        for ns in var.allowed_namespaces : {
+          namespace = ns
+          server    = "https://kubernetes.default.svc"
+        }
+      ]
+      clusterResourceWhitelist = [
+        { group = "*", kind = "*" }
+      ]
+      orphanedResources = {
+        warn = true
+      }
+    }
+  }
+  depends_on = [
+    helm_release.argocd,
+  ]
+}
+
+resource "kubernetes_manifest" "argocd_app_root" {
+  manifest = {
+    apiVersion = "argoproj.io/v1alpha1"
+    kind       = "Application"
+    metadata = {
+      name      = "cloudnative-observability-root"
+      namespace = kubernetes_namespace.argocd.metadata[0].name
+      finalizers = [
+        "resources-finalizer.argocd.argoproj.io"
+      ]
+      labels = {
+        "app.kubernetes.io/managed-by" = "terraform"
+      }
+    }
+    spec = {
+      project = kubernetes_manifest.argocd_project_cno.manifest.metadata.name
+
+      source = {
+        repoURL        = var.root_repo_url
+        targetRevision = var.root_repo_revision
+        path           = "apps"
+        directory = {
+          recurse = true
+        }
+      }
+
+      destinations = {
+        server    = "https://kubernetes.default.svc"
+        namespace = "argocd"
+      }
+
+      syncPolicy = {
+        automated = {
+          prune    = true
+          selfHeal = true
+        }
+        syncOptions = [
+          "CreateNamespace=true",
+          "ApplyOutOfSyncOnly=true"
+        ]
+      }
+    }
+  }
+  depends_on = [
+    helm_release.argocd,
+    kubernetes_manifest.argocd_project_cno,
+  ]
+}

--- a/environments/dev/backend.tf
+++ b/environments/dev/backend.tf
@@ -1,9 +1,9 @@
 terraform {
   backend "s3" {
-    bucket = "cloudnative-observability-tf-global-318839415844-ap-northeast-1"
-    key = "dev/terraform.tfstate"
-    region = "ap-northeast-1"
+    bucket         = "cloudnative-observability-tf-global-318839415844-ap-northeast-1"
+    key            = "dev/terraform.tfstate"
+    region         = "ap-northeast-1"
     dynamodb_table = "cloudnative-observability-tf-locks"
-    encrypt = true
+    encrypt        = true
   }
 }

--- a/environments/dev/eks/main.tf
+++ b/environments/dev/eks/main.tf
@@ -3,18 +3,18 @@ locals {
 }
 
 module "eks" {
-  source = "terraform-aws-modules/eks/aws"
+  source  = "terraform-aws-modules/eks/aws"
   version = "~> 20.0"
 
   # Core
-  cluster_name = var.cluster_name
+  cluster_name    = var.cluster_name
   cluster_version = var.cluster_version
 
-  vpc_id = var.vpc_id
+  vpc_id     = var.vpc_id
   subnet_ids = var.private_subnets
 
   # endpoint access
-  cluster_endpoint_public_access = var.endpoint_public_access
+  cluster_endpoint_public_access  = var.endpoint_public_access
   cluster_endpoint_private_access = var.endpoint_private_access
 
   # IRSA
@@ -24,29 +24,29 @@ module "eks" {
   eks_managed_node_groups = {
     default = {
       instance_types = var.node_instance_types
-      capacity_type = "ON_DEMAND"
+      capacity_type  = "ON_DEMAND"
 
-      min_size = var.node_min_size
+      min_size     = var.node_min_size
       desired_size = var.node_desired_size
-      max_size = var.node_max_size
-      disk_size = var.node_disk_size
+      max_size     = var.node_max_size
+      disk_size    = var.node_disk_size
 
       subnet_ids = var.private_subnets
-      labels = { "workload" = "general" }
+      labels     = { "workload" = "general" }
     }
   }
 
   tags = merge(
     {
       "Project" = var.project
-      "Env" = var.env
+      "Env"     = var.env
     },
     var.tags
   )
 }
 
 module "eks_aws_auth" {
-  source = "terraform-aws-modules/eks/aws//modules/aws-auth"
+  source  = "terraform-aws-modules/eks/aws//modules/aws-auth"
   version = "~> 20.0"
 
   manage_aws_auth_configmap = true
@@ -58,5 +58,5 @@ module "eks_aws_auth" {
     kubernetes = kubernetes
   }
 
-  depends_on = [ module.eks ]
+  depends_on = [module.eks]
 }

--- a/environments/dev/eks/outputs.tf
+++ b/environments/dev/eks/outputs.tf
@@ -1,32 +1,32 @@
 output "cluster_name" {
   description = "EKS cluster name"
-  value = module.eks.cluster_name
+  value       = module.eks.cluster_name
 }
 
 output "cluster_arn" {
   description = "EKS cluster ARN"
-  value = module.eks.cluster_arn
+  value       = module.eks.cluster_arn
 }
 
 output "cluster_endpoint" {
   description = "EKS API server endpoint"
-  value = module.eks.cluster_endpoint
+  value       = module.eks.cluster_endpoint
 }
 
 output "cluster_certificate_authority_data" {
   description = "Base64-encoded cluster CA"
-  value = module.eks.cluster_certificate_authority_data
+  value       = module.eks.cluster_certificate_authority_data
 }
 
 output "oidc_provider_arn" {
   description = "OIDC provider ARN for IRSA"
-  value = module.eks.oidc_provider_arn
+  value       = module.eks.oidc_provider_arn
 }
 
 output "managed_node_group_names" {
   description = "EKS managed node group names"
-  value = keys(module.eks.eks_managed_node_groups)
-  }
+  value       = keys(module.eks.eks_managed_node_groups)
+}
 
 output "cluster_oidc_issuer_url" {
   value = module.eks.cluster_oidc_issuer_url

--- a/environments/dev/eks/variables.tf
+++ b/environments/dev/eks/variables.tf
@@ -1,88 +1,88 @@
 variable "project" {
   description = "Project name tag"
-  type = string
+  type        = string
 }
 
 variable "env" {
   description = "Environment name tag (e.g. dev)"
-  type = string
+  type        = string
 }
 
 variable "cluster_name" {
   description = "EKS cluster name"
-  type = string
+  type        = string
 }
 
 variable "cluster_version" {
   description = "EKS version (e.g. 1.29)"
-  type = string
-  default = "1.29"
+  type        = string
+  default     = "1.29"
 }
 
 variable "vpc_id" {
   description = "VPC ID where EKS will be created"
-  type = string
+  type        = string
 }
 
 variable "private_subnets" {
   description = "Private subnet IDs for worker nodes"
-  type = list(string)
+  type        = list(string)
 }
 
 variable "public_subnets" {
   description = "Public subnet IDs (optional, for LB etc.)"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 
 variable "endpoint_public_access" {
   description = "Enable public API endpoint"
-  type = bool
-  default = true
+  type        = bool
+  default     = true
 }
 
 variable "endpoint_private_access" {
   description = "Enable private API endpoint"
-  type = bool
-  default = true
+  type        = bool
+  default     = true
 }
 
 variable "node_instance_types" {
   description = "Instance types for the default managed node group"
-  type = list(string)
-  default = [ "t3.medium" ]
+  type        = list(string)
+  default     = ["t3.medium"]
 }
 
 variable "node_desired_size" {
   description = "Desired size for the default node group"
-  type = number
-  default = 2
+  type        = number
+  default     = 2
 }
 
 variable "node_min_size" {
   description = "Min size for the default node group"
-  type = number
-  default = 1
+  type        = number
+  default     = 1
 }
 
 variable "node_max_size" {
   description = "Max size for the default node group"
-  type = number
-  default = 3
+  type        = number
+  default     = 3
 }
 
 variable "node_disk_size" {
   description = "Node root volume size (GiB)"
-  type = number
-  default = 20
+  type        = number
+  default     = 20
 }
 
 variable "aws_auth_roles" {
   description = "aws-auth role mappings"
   type = list(object({
-    rolearn = string
+    rolearn  = string
     username = string
-    groups = list(string)
+    groups   = list(string)
   }))
   default = []
 }
@@ -90,21 +90,21 @@ variable "aws_auth_roles" {
 variable "aws_auth_users" {
   description = "aws-auth user mappings"
   type = list(object({
-    userarn = string
+    userarn  = string
     username = string
-    groups = list(string)
+    groups   = list(string)
   }))
   default = []
 }
 
 variable "aws_auth_accounts" {
   description = "aws-auth account IDs"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 
 variable "tags" {
   description = "Extra tags"
-  type = map(string)
-  default = {}
+  type        = map(string)
+  default     = {}
 }

--- a/environments/dev/helm_provider.tf
+++ b/environments/dev/helm_provider.tf
@@ -1,8 +1,8 @@
 provider "helm" {
   alias = "eks"
   kubernetes {
-    host = data.aws_eks_cluster.this.endpoint
+    host                   = data.aws_eks_cluster.this.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority[0].data)
-    token = data.aws_eks_cluster_auth.this.token
+    token                  = data.aws_eks_cluster_auth.this.token
   }
 }

--- a/environments/dev/iam_irsa.tf
+++ b/environments/dev/iam_irsa.tf
@@ -1,73 +1,73 @@
 locals {
   oidc_provider_arn = module.eks.oidc_provider_arn
-  oidc_issuer_url = module.eks.cluster_oidc_issuer_url
+  oidc_issuer_url   = module.eks.cluster_oidc_issuer_url
 
   tags = {
     Project = "cloudnative-observability"
-    Env = "dev"
+    Env     = "dev"
   }
 }
 
 # Argo CD:s3読取(helmリポジトリ)
 variable "argocd_s3_bucket_name" {
-  type = string
+  type        = string
   description = "Argo CDがHelm Chartを取得するS3バケット名(read-only)"
 }
 
 data "aws_iam_policy_document" "argocd_s3_ro" {
   statement {
-    sid = "ListBucket"
-    effect = "Allow"
-    actions = [ "s3:ListBucket" ]
+    sid     = "ListBucket"
+    effect  = "Allow"
+    actions = ["s3:ListBucket"]
     resources = [
       "arn:aws:s3:::${var.argocd_s3_bucket_name}"
     ]
   }
   statement {
-    sid = "GetObjects"
+    sid    = "GetObjects"
     effect = "Allow"
     actions = [
       "s3:GetObject",
       "s3:GetObjectVersion"
-     ]
-     resources = [
+    ]
+    resources = [
       "arn:aws:s3:::${var.argocd_s3_bucket_name}/*"
-     ]
+    ]
   }
 }
 
 module "irsa_argocd" {
-  source = "../../modules/irsa-role"
-  name = "argocd-app-controller"
-  namespace = "argocd"
-  service_account = "argocd-application-controller"
-  oidc_provider_arn = local.oidc_provider_arn
-  oidc_issuer_url = local.oidc_issuer_url
-  policy_json = data.aws_iam_policy_document.argocd_s3_ro.json
-  policy_arns = []
-  create_namespace = false
+  source                 = "../../modules/irsa-role"
+  name                   = "argocd-app-controller"
+  namespace              = "argocd"
+  service_account        = "argocd-application-controller"
+  oidc_provider_arn      = local.oidc_provider_arn
+  oidc_issuer_url        = local.oidc_issuer_url
+  policy_json            = data.aws_iam_policy_document.argocd_s3_ro.json
+  policy_arns            = []
+  create_namespace       = false
   create_service_account = false
-  tags = local.tags
+  tags                   = local.tags
 }
 
 variable "sealed_secrets_backup_bucket" {
-  type = string
+  type        = string
   description = "Sealed Secretsの鍵バックアップ用S3バケット"
 }
 
 data "aws_iam_policy_document" "sealed_s3_rw" {
   statement {
-    sid = "ListBucket"
-    effect = "Allow"
+    sid     = "ListBucket"
+    effect  = "Allow"
     actions = ["s3:ListBucket"]
     resources = [
       "arn:aws:s3:::${var.sealed_secrets_backup_bucket}"
     ]
   }
   statement {
-    sid = "PutGetObjects"
-    effect = "Allow"
-    actions = [ "s3:GetObject", "s3:PutObject" ]
+    sid     = "PutGetObjects"
+    effect  = "Allow"
+    actions = ["s3:GetObject", "s3:PutObject"]
     resources = [
       "arn:aws:s3:::${var.sealed_secrets_backup_bucket}/*"
     ]
@@ -75,25 +75,25 @@ data "aws_iam_policy_document" "sealed_s3_rw" {
 }
 
 module "irsa_sealed_secrets" {
-  source = "../../modules/irsa-role"
-  name = "sealed-secrets-controller"
-  namespace = "sealed-secrets"
-  service_account = "sealed-secrets-controller"
-  oidc_provider_arn = local.oidc_provider_arn
-  oidc_issuer_url = local.oidc_issuer_url
-  policy_json = data.aws_iam_policy_document.sealed_s3_rw.json
-  policy_arns = []
-  create_namespace = true
+  source                 = "../../modules/irsa-role"
+  name                   = "sealed-secrets-controller"
+  namespace              = "sealed-secrets"
+  service_account        = "sealed-secrets-controller"
+  oidc_provider_arn      = local.oidc_provider_arn
+  oidc_issuer_url        = local.oidc_issuer_url
+  policy_json            = data.aws_iam_policy_document.sealed_s3_rw.json
+  policy_arns            = []
+  create_namespace       = true
   create_service_account = true
-  tags = local.tags
+  tags                   = local.tags
 }
 
 # OpenTelemetry Collector: CloudWatch Logs & X-Ray (任意)
 
 variable "otelcloudwatch_log_group_arn" {
-  type = string
+  type        = string
   description = "Otel Collectorが出力するCloudWatch LogsのLogGroup ARN"
-  default = "null"
+  default     = "null"
 }
 
 locals {
@@ -104,15 +104,15 @@ locals {
 }
 
 module "irsa_otel" {
-  source = "../../modules/irsa-role"
-  name = "otel-collector"
-  namespace = "monitoring"
-  service_account = "otel-collector"
-  oidc_provider_arn = local.oidc_provider_arn
-  oidc_issuer_url = local.oidc_issuer_url
-  policy_json = null
-  policy_arns = local.otel_managed_policies
-  create_namespace = true
+  source                 = "../../modules/irsa-role"
+  name                   = "otel-collector"
+  namespace              = "monitoring"
+  service_account        = "otel-collector"
+  oidc_provider_arn      = local.oidc_provider_arn
+  oidc_issuer_url        = local.oidc_issuer_url
+  policy_json            = null
+  policy_arns            = local.otel_managed_policies
+  create_namespace       = true
   create_service_account = true
-  tags = local.tags
+  tags                   = local.tags
 }

--- a/environments/dev/kube_provider.tf
+++ b/environments/dev/kube_provider.tf
@@ -7,8 +7,8 @@ data "aws_eks_cluster_auth" "this" {
 }
 
 provider "kubernetes" {
-  alias = "eks"
-  host = data.aws_eks_cluster.this.endpoint
+  alias                  = "eks"
+  host                   = data.aws_eks_cluster.this.endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority[0].data)
-  token = data.aws_eks_cluster_auth.this.token
+  token                  = data.aws_eks_cluster_auth.this.token
 }

--- a/environments/dev/main.eks.tf
+++ b/environments/dev/main.eks.tf
@@ -2,20 +2,20 @@ module "eks" {
   source = "./eks"
 
   project = var.project
-  env = var.env
+  env     = var.env
 
-  cluster_name = "grpc-observability-cluster"
+  cluster_name    = "grpc-observability-cluster"
   cluster_version = "1.29"
 
-  vpc_id = module.network.vpc_id
+  vpc_id          = module.network.vpc_id
   private_subnets = module.network.private_subnets
-  public_subnets = module.network.public_subnets
+  public_subnets  = module.network.public_subnets
 
-  endpoint_public_access = true
+  endpoint_public_access  = true
   endpoint_private_access = true
 
-  aws_auth_roles = []
-  aws_auth_users = []
+  aws_auth_roles    = []
+  aws_auth_users    = []
   aws_auth_accounts = []
 
   providers = {

--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -1,6 +1,6 @@
 module "network" {
-  source = "./network"
-  project     = var.project
-  env         = var.env
-  aws_region  = var.aws_region
+  source     = "./network"
+  project    = var.project
+  env        = var.env
+  aws_region = var.aws_region
 }

--- a/environments/dev/network/main.tf
+++ b/environments/dev/network/main.tf
@@ -1,7 +1,7 @@
 locals {
   common_tags = {
-    Project = var.project
-    Env = var.env
+    Project   = var.project
+    Env       = var.env
     ManagedBy = "Terraform"
     Component = "network"
   }
@@ -16,15 +16,15 @@ module "vpc" {
   name = "${var.project}-${var.env}-vpc"
   cidr = var.vpc_cidr
 
-  azs = var.azs
-  public_subnets = var.public_subnets
+  azs             = var.azs
+  public_subnets  = var.public_subnets
   private_subnets = var.private_subnets
 
   enable_dns_hostnames = true
   enable_dns_support   = true
 
-  enable_nat_gateway = true
-  single_nat_gateway = true
+  enable_nat_gateway     = true
+  single_nat_gateway     = true
   one_nat_gateway_per_az = false
 
   create_igw = true
@@ -34,8 +34,8 @@ module "vpc" {
   public_subnet_tags = merge(
     local.common_tags,
     {
-      Name = "${var.project}-${var.env}-public"
-      "kubernetes.io/role/elb" = 1
+      Name                        = "${var.project}-${var.env}-public"
+      "kubernetes.io/role/elb"    = 1
       (local.eks_cluster_tag_key) = "shared"
     }
   )
@@ -43,9 +43,9 @@ module "vpc" {
   private_subnet_tags = merge(
     local.common_tags,
     {
-      Name = "${var.project}-${var.env}-private"
+      Name                              = "${var.project}-${var.env}-private"
       "kubernetes.io/role/internal-elb" = 1
-      (local.eks_cluster_tag_key)= "shared"
+      (local.eks_cluster_tag_key)       = "shared"
     }
   )
 

--- a/environments/dev/network/outputs.tf
+++ b/environments/dev/network/outputs.tf
@@ -1,39 +1,39 @@
 output "vpc_id" {
   description = "VPC ID"
-  value = module.vpc.vpc_id
+  value       = module.vpc.vpc_id
 }
 
 output "vpc_cidr_block" {
   description = "VPC CIDR"
-  value = module.vpc.vpc_cidr_block
+  value       = module.vpc.vpc_cidr_block
 }
 
 output "azs" {
   description = "AZs used"
-  value = module.vpc.azs
+  value       = module.vpc.azs
 }
 
 output "public_subnets" {
   description = "Public subnet IDs"
-  value = module.vpc.public_subnets
+  value       = module.vpc.public_subnets
 }
 
 output "private_subnets" {
   description = "Private subnet IDs"
-  value = module.vpc.private_subnets
+  value       = module.vpc.private_subnets
 }
 
 output "public_route_table_ids" {
   description = "Public route table IDs"
-  value = module.vpc.public_route_table_ids
+  value       = module.vpc.public_route_table_ids
 }
 
 output "private_route_table_ids" {
   description = "Private route table IDs"
-  value = module.vpc.private_route_table_ids
+  value       = module.vpc.private_route_table_ids
 }
 
 output "nat_public_ips" {
   description = "NAT Gateway public IPs"
-  value = module.vpc.nat_public_ips
+  value       = module.vpc.nat_public_ips
 }

--- a/environments/dev/network/variables.tf
+++ b/environments/dev/network/variables.tf
@@ -24,7 +24,7 @@ variable "azs" {
   description = "Availability Zones to use"
   type        = list(string)
   # ap-northeast-1 の3AZ例（アカウントで利用可なAZに合わせて調整可）
-  default     = ["ap-northeast-1a", "ap-northeast-1c", "ap-northeast-1d"]
+  default = ["ap-northeast-1a", "ap-northeast-1c", "ap-northeast-1d"]
 }
 
 variable "public_subnets" {

--- a/environments/dev/providers.tf
+++ b/environments/dev/providers.tf
@@ -2,10 +2,10 @@ provider "aws" {
   region = var.aws_region
   default_tags {
     tags = {
-      Project = var.project
+      Project     = var.project
       Environment = var.env
-      ManagedBy = "Terraform"
-      Component = "infra"
+      ManagedBy   = "Terraform"
+      Component   = "infra"
     }
   }
 }

--- a/environments/dev/variables.appofapps.dev.tfvars
+++ b/environments/dev/variables.appofapps.dev.tfvars
@@ -1,0 +1,13 @@
+repo_owner         = "shtsukada"
+root_repo_url      = "https://github.com/shtsukada/cloudnative-observability"
+root_repo_revision = "main"
+
+source_repos_allowlist = [
+  "https://github.com/shtsukada/*",
+]
+
+allowed_namespaces = [
+  "argocd",
+  "monitoring",
+  "grpc-app",
+]

--- a/environments/dev/variables.appofapps.tf
+++ b/environments/dev/variables.appofapps.tf
@@ -1,0 +1,27 @@
+variable "repo_owner" {
+  description = "GitHub shtsukada/org"
+  type        = string
+}
+
+variable "root_repo_url" {
+  description = "app-of-appsを置くルートリポジトリ_https://github.com/shtsukada/cloudnative-observability"
+  type        = string
+}
+
+variable "root_repo_revision" {
+  description = "ルートリポジトリの参照(tag / branch)"
+  type        = string
+  default     = "main"
+}
+
+variable "allowed_namespaces" {
+  description = "AppProjectで許可する配備先Namespace"
+  type        = list(string)
+  default     = ["argocd", "monitoring", "grpc-app"]
+}
+
+variable "source_repos_allowlist" {
+  description = "AppProjectに許可するGitリポジトリURL群"
+  type        = list(string)
+  default     = []
+}

--- a/environments/dev/variables.irsa.tfvars
+++ b/environments/dev/variables.irsa.tfvars
@@ -1,3 +1,3 @@
-argocd_s3_bucket_name = "cno-dev-argocd-helm-repo"
+argocd_s3_bucket_name        = "cno-dev-argocd-helm-repo"
 sealed_secrets_backup_bucket = "cno-dev-sealed-secrets-backup"
 # otelcloudwatch_log_group_arn = "arn:aws:logs:ap-northeast-1:318839415844:log-group:/aws/eks/cloudnative-observability/*"

--- a/environments/dev/variables.tf
+++ b/environments/dev/variables.tf
@@ -1,14 +1,14 @@
 variable "aws_region" {
-  type = string
+  type    = string
   default = "ap-northeast-1"
 }
 
 variable "env" {
-  type = string
+  type    = string
   default = "dev"
 }
 
 variable "project" {
-  type = string
+  type    = string
   default = "cloudnative-observability"
 }

--- a/environments/dev/versions.tf
+++ b/environments/dev/versions.tf
@@ -7,11 +7,11 @@ terraform {
       version = ">= 5.79.0, < 6.0.0"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
       version = "~> 2.32"
     }
     helm = {
-      source = "hashicorp/helm"
+      source  = "hashicorp/helm"
       version = "~> 2.13"
     }
   }


### PR DESCRIPTION
## 概要
- Argo CDにおいてapp-of-appsパターンを採用し、ガードレール(AppProject)とRoot ApplicationをTerraformで管理できるようにしました。これにより、ルートリポジトリ apps/ディレクトリに定義した子ApplicationをArgo CDが自動検出、同期します。

## 変更点
- environments/dev/argocd_appofapps.tf
  - AppProject cloudnative-observabilityを追加
  - root Application cloudnative-observability-rootを追加(app-of-appsパターン)
- environments/dev/variables.appofapps.tf
  - 変数定義(repo_owner, root_repo_url, root_repo_revision, etc)を追加
- environments/dev/variables.appofapps.dev.tfvars
  - dev 環境用の具体値を追加（誰でも再現可能）