### PR TITLE
feat(namespaces-secrets):namespace追加とSealedSecrets設定

### DIFF
--- a/environments/dev/namespaces.tf
+++ b/environments/dev/namespaces.tf
@@ -1,0 +1,26 @@
+resource "kubernetes_namespace" "grpc_app" {
+  metadata {
+    name = "grpc-app"
+    labels = {
+      "pod-security.kubernetes.io/enforce" = "restricted"
+    }
+  }
+}
+
+resource "kubernetes_namespace" "monitoring" {
+  metadata {
+    name = "monitoring"
+    labels = {
+      "pod-security.kubernetes.io/enforce" = "restricted"
+    }
+  }
+}
+
+resource "kubernetes_namespace" "sealed_secrets" {
+  metadata {
+    name = "sealed-secrets"
+    labels = {
+      "pod-security.kubernetes.io/enforce" = "restricted"
+    }
+  }
+}

--- a/environments/dev/outputs.sealedsecrets.tf
+++ b/environments/dev/outputs.sealedsecrets.tf
@@ -1,0 +1,16 @@
+data "kubernetes_secret" "sealed_secrets_key" {
+  metadata {
+    name = "sealed-secrets-key"
+    namespace = kubernetes_namespace.sealed_secrets.metadata[0].name
+  }
+  depends_on = [helm_release.sealed_secrets]
+}
+
+locals {
+  sealed_secrets_public_cert_pem = base64decode(lookup(data.kubernetes_secret.sealed_secrets_key.data, "tls.crt", ""))
+}
+
+output "sealed_secrets_public_cert_pem" {
+  description = "Public certificate (PEM) for kubeseal --cert"
+  value = local.sealed_secrets_public_cert_pem
+}

--- a/environments/dev/sealedsecrets.tf
+++ b/environments/dev/sealedsecrets.tf
@@ -1,0 +1,14 @@
+resource "helm_release" "sealed_secrets" {
+  name = "sealed-secrets"
+  repository = "https://bitnami-labs.github.io/sealed-secrets"
+  chart = "sealed-secrets"
+  version = var.sealed_secrets_chart_version
+
+  namespace = kubernetes_namespace.sealed_secrets.metadata[0].name
+  create_namespace = false
+
+  wait = true
+  atomic = true
+  cleanup_on_fail = true
+  timeout = 600
+}

--- a/environments/dev/variables.sealedsecrets.tf
+++ b/environments/dev/variables.sealedsecrets.tf
@@ -1,0 +1,11 @@
+variable "sealed_secrets_chart_version" {
+  type = string
+  description = "bitnami-labs/sealed-secrets chart version"
+  default = "2.16.2"
+}
+
+variable "sealed_secrets_namespace" {
+  type = string
+  description = "Namespace for sealed-secrets controller"
+  default = "sealed-secrets"
+}


### PR DESCRIPTION
## 概要
- grpc-app / monitoring / sealed-secrets Namespace を作成
- sealed-secrets Controller を Helm リリースで導入
- sealed-secrets のチャートバージョンを変数化
- 公開鍵（tls.crt）を Terraform Output 経由で取得できるように整備

## 目的
- 今後 GitOps 運用で Slack Webhook 等の機密情報を扱うために、SealedSecrets を利用可能な基盤を構築する
- Secret を平文で GitHub に保存せず、安全に暗号化して管理できるようにする
- ArgoCD app-of-apps 配下の monitoring や app リポで SealedSecret を利用可能にする

## 変更点
- namespaces.tf : grpc-app / monitoring / sealed-secrets Namespace 定義
- sealedsecrets.tf : sealed-secrets Controller の Helm 導入
- variables.sealedsecrets.tf : sealed-secrets の chart version を変数化
- outputs.sealedsecrets.tf : 公開鍵 (tls.crt) を Terraform output で出力