### PR TITLE
feat(github-actions-ci):Terraform CIワークフロー及びOIDC IAM role追加

### DIFF
--- a/.github/workflows/apply-dev.yml
+++ b/.github/workflows/apply-dev.yml
@@ -1,0 +1,50 @@
+name: Terraform Apply (dev on main)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'environments/dev/**'
+      - '.github/workflows/apply-dev.yml'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: terraform-apply-dev
+  cancel-in-progress: false
+
+jobs:
+  apply-dev:
+    runs-on: ubuntu-latest
+    environment: dev
+    defaults:
+      run:
+        working-directory: environments/dev
+    env:
+      TF_IN_AUTOMATION: "true"
+      TF_INPUT: "false"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.9.x
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME_DEV }}
+          aws-region: ap-northeast-1
+
+      - name: Terraform init
+        run: terraform init -input=false -no-color
+
+      - name: Terraform plan (for visibility)
+        run: terraform plan -no-color -out=plan.out | tee plan_stdout.txt
+
+      - name: Terraform apply (dev)
+        run: terraform apply -auto-approve -input=false plan.out

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,128 @@
+name: Terraform CI (fmt/validate/plan)
+
+on: 
+  pull_request: 
+    branches: [ main ]
+    paths: 
+      - 'environments/dev/**'
+      - '.github/workflows/ci.yml'
+  workflow_dispatch: {}
+
+permissions: 
+  contents: read
+  id-token: write
+  pull-requests: write
+
+concurrency: 
+  group: terraform-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  terraform-ci:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: environments/dev
+
+    env:
+      TF_IN_AUTOMATION: "true"
+      TF_INPUT: "false"
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.9.x
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME_DEV }}
+          aws-region: ap-northeast-1
+
+      - name: Terraform fmt (check)
+        id: fmt
+        run: terraform fmt -check -recursive
+
+      - name: Terraform init
+        id: init
+        run: terraform init -input=false -no-color
+
+      - name: Terraform validate
+        id: validate
+        run: terraform validate -no-color
+
+      - name: Terraform plan (dev)
+        id: plan
+        run: |
+          terraform plan -no-color -out=plan.out | tee plan_stdout.txt
+          terraform show -no-color plan.out > plan.txt
+
+      - name: Upload plan artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tfplan-dev
+          path: |
+            environments/dev/plan.out
+            environments/dev/plan.txt
+            environments/dev/plan_stdout.txt
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Comment plan summary to PR
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = 'environments/dev/plan.txt';
+            const body = fs.readFileSync(path, 'utf8');
+
+            // うるさくなりすぎないよう、先頭1000行に抑制
+            const lines = body.split('\n').slice(0, 1000).join('\n');
+            const comment = [
+              '### Terraform plan (dev)',
+              '',
+              '```\n' + lines + '\n```',
+              '',
+              '> フルログや plan.out は Actions の Artifacts から参照できます。'
+            ].join('\n');
+
+            // 既存の自分のコメントがあれば更新
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const marker = 'Terraform plan (dev)';
+            const mine = comments.find(c => c.user.type === 'Bot' && c.body && c.body.includes(marker));
+
+            if (mine) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: mine.id,
+                body: comment
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: comment
+              });
+            }
+
+      - name: Fail if any step failed
+        if: |
+          steps.fmt.outcome != 'success' ||
+          steps.init.outcome != 'success' ||
+          steps.validate.outcome != 'success' ||
+          steps.plan.outcome != 'success'
+        run: |
+          echo "::error::Terraform CI failed (fmt/init/validate/plan check)."
+          exit 1

--- a/environments/dev/.terraform.lock.hcl
+++ b/environments/dev/.terraform.lock.hcl
@@ -3,7 +3,7 @@
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.100.0"
-  constraints = "~> 5.60, >= 5.79.0, < 6.0.0"
+  constraints = ">= 4.33.0, >= 5.79.0, >= 5.95.0, < 6.0.0"
   hashes = [
     "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
     "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
@@ -45,28 +45,28 @@ provider "registry.terraform.io/hashicorp/cloudinit" {
 }
 
 provider "registry.terraform.io/hashicorp/helm" {
-  version     = "2.17.0"
-  constraints = "~> 2.13"
+  version     = "2.13.0"
+  constraints = "2.13.0"
   hashes = [
-    "h1:kQMkcPVvHOguOqnxoEU2sm1ND9vCHiT8TvZ2x6v/Rsw=",
-    "zh:06fb4e9932f0afc1904d2279e6e99353c2ddac0d765305ce90519af410706bd4",
-    "zh:104eccfc781fc868da3c7fec4385ad14ed183eb985c96331a1a937ac79c2d1a7",
-    "zh:129345c82359837bb3f0070ce4891ec232697052f7d5ccf61d43d818912cf5f3",
-    "zh:3956187ec239f4045975b35e8c30741f701aa494c386aaa04ebabffe7749f81c",
-    "zh:66a9686d92a6b3ec43de3ca3fde60ef3d89fb76259ed3313ca4eb9bb8c13b7dd",
-    "zh:88644260090aa621e7e8083585c468c8dd5e09a3c01a432fb05da5c4623af940",
-    "zh:a248f650d174a883b32c5b94f9e725f4057e623b00f171936dcdcc840fad0b3e",
-    "zh:aa498c1f1ab93be5c8fbf6d48af51dc6ef0f10b2ea88d67bcb9f02d1d80d3930",
-    "zh:bf01e0f2ec2468c53596e027d376532a2d30feb72b0b5b810334d043109ae32f",
-    "zh:c46fa84cc8388e5ca87eb575a534ebcf68819c5a5724142998b487cb11246654",
-    "zh:d0c0f15ffc115c0965cbfe5c81f18c2e114113e7a1e6829f6bfd879ce5744fbb",
+    "h1:jGANeRsj81e6I6LYTV7s+7bOfeb6wtVssAOnbu+ZUWg=",
+    "zh:016e42bea1c9145b0856bfcf1e5faf657e40e9a94e4d80bee9e0b8742eb9f5fd",
+    "zh:0a325cfcb62d4c611a9a7854d2ca26ee8cbd27a1cae40f607c0966e36a858358",
+    "zh:2e22929aa1cc59c02e1cb8af8cee25063a706cdfc15d3aff242c8bf76cd12ea3",
+    "zh:35d989aa6f43d6401077c190c3262c6df434290c5bec978079ae69eb33f3929e",
+    "zh:4cc42ee66af3fa965424c19904e5ac52326d4a31df066d565d591d0e46e64c2d",
+    "zh:69a429be3f7183f53ec1928a44ed7ad0606a0247a7ce34e2c5a8e9d8906dbcbd",
+    "zh:88155234e7a4d45cc91ebcb2d633fdfc2daad4e85e5b1990c864dab0432afa0e",
+    "zh:b13055e38617be147e82eec8b20c579e9c202da9ead8c976a54ed08bde6b06f7",
+    "zh:bc6f8f1f84afcc66c5b248ffa34580d8f7e7552628eb6ad044765513159db8e4",
+    "zh:d91899fe77e7223d91d2cfed2cacde1afe8b528771402ec4d494b81457421bb1",
+    "zh:ef5ca86c48a786a0cc481f4cfb1c9f2e3b8eccb640c106c6a1f253f97f5e9c55",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/kubernetes" {
   version     = "2.38.0"
-  constraints = ">= 2.20.0, ~> 2.32"
+  constraints = ">= 2.20.0, ~> 2.30"
   hashes = [
     "h1:soK8Lt0SZ6dB+HsypFRDzuX/npqlMU6M0fvyaR1yW0k=",
     "zh:0af928d776eb269b192dc0ea0f8a3f0f5ec117224cd644bdacdc682300f84ba0",

--- a/environments/dev/iam_github_oidc.tf
+++ b/environments/dev/iam_github_oidc.tf
@@ -1,0 +1,148 @@
+locals {
+  common_tags = {
+    Project = var.project
+    Env =var.env
+    Managed = "terraform"
+  }
+}
+
+resource "aws_iam_openid_connect_provider" "github" {
+  url = "https://token.actions.githubusercontent.com"
+
+  client_id_list = [
+    "sts.amazonaws.com",
+  ]
+
+  thumbprint_list = [
+    "6938fd4d98bab03faadb97b34396831e3780aea1",
+  ]
+
+  tags = local.common_tags
+}
+
+resource "aws_iam_role" "gha_terraform_dev" {
+  name = "gha-terraform-dev"
+  assume_role_policy = data.aws_iam_policy_document.gha_trust.json
+  tags = local.common_tags
+}
+
+data "aws_iam_policy_document" "gha_trust" {
+  statement {
+    sid = "GitHubOIDCTrust"
+    effect = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.github.arn]
+    }
+
+    condition {
+      test = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values = [
+        "repo:{var.var.github_org}/${var.var.github_repo}:pull_request",
+        "repo:{var.var.github_org}/${var.var.github_repo}:refs/heads/main",
+      ]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "gha_permissions" {
+  statement {
+    sid = "TfBackend"
+    effect = "Allow"
+    actions = [
+      "s3:ListBucket",
+    ]
+    resources = [
+      "arn:aws:s3:::${var.tfstate_bucket}",
+    ]
+  }
+
+  statement {
+    sid = "TfBackendObjects"
+    effect = "Allow"
+    actions = [
+      "S3:GetObject",
+      "S3:PutObject",
+      "S3:DeleteObject",
+    ]
+    resources = [
+      "arn:aws:s3:::${var.tfstate_bucket}/*",
+    ]
+  }
+
+  statement {
+    sid = "TfStateLock"
+    effect = "Allow"
+    actions = [
+      "dynamodb:GetItem",
+      "dynamodb:PutItem",
+      "dynamodb:DeleteItem",
+      "dynamodb:UpdateItem",
+    ]
+    resources = [
+      "arn:aws:dynamodb:${var.aws_region}:*:table/${var.lock_table_name}",
+    ]
+  }
+
+  statement {
+    sid    = "ReadDescribe"
+    effect = "Allow"
+    actions = [
+      "ec2:Describe*",
+      "eks:Describe*",
+      "iam:GetRole",
+      "iam:ListAttachedRolePolicies",
+      "iam:ListRolePolicies",
+      "logs:Describe*",
+      "elasticloadbalancing:Describe*",
+      "autoscaling:Describe*",
+      "sts:AssumeRole", # 必要に応じて
+    ]
+    resources = ["*"]
+  }
+  statement {
+    sid    = "CreateUpdateDeleteDev"
+    effect = "Allow"
+    actions = [
+      "ec2:*",
+      "eks:*",
+      "iam:CreateRole",
+      "iam:AttachRolePolicy",
+      "iam:PutRolePolicy",
+      "iam:DeleteRolePolicy",
+      "iam:DetachRolePolicy",
+      "iam:DeleteRole",
+      "iam:PassRole",
+      "elasticloadbalancing:*",
+      "autoscaling:*",
+      "logs:*",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "gha_permissions" {
+  name        = "gha-terraform-dev-permissions"
+  description = "Permissions for GitHub Actions Terraform (dev)"
+  policy      = data.aws_iam_policy_document.gha_permissions.json
+  tags        = local.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "gha_attach" {
+  role       = aws_iam_role.gha_terraform_dev.name
+  policy_arn = aws_iam_policy.gha_permissions.arn
+}
+
+output "gha_terraform_dev_role_arn" {
+  value       = aws_iam_role.gha_terraform_dev.arn
+  description = "Assumable role ARN for GitHub Actions (set to AWS_ROLE_TO_ASSUME_DEV)"
+}

--- a/environments/dev/variables.gh_oidc.tf
+++ b/environments/dev/variables.gh_oidc.tf
@@ -1,0 +1,19 @@
+variable "github_org" {
+  type = string
+  description = "GitHub organization/user (e.g.,shtsukada)"
+}
+
+variable "github_repo" {
+  type = string
+  description = "Github repository name (e.g., cloudnative-observability-infra)"
+}
+
+variable "tfstate_bucket" {
+  type = string
+  description = "Terraform backend S3 bucket name"
+}
+
+variable "lock_table_name" {
+  type = string
+  description = "Terraform backend DynamoDB lock table name"
+}

--- a/environments/dev/versions.tf
+++ b/environments/dev/versions.tf
@@ -8,11 +8,11 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.32"
+      version = "~> 2.30"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.13"
+      version = "= 2.13"
     }
   }
 }


### PR DESCRIPTION
## 概要
Terraform CI（fmt/validate/plan）を導入し、PR時に自動検証＋plan結果をコメントで共有するようにしました。  
ブランチ保護ルールと併用することで、main への不正な変更（フォーマット崩れ・検証失敗・plan未確認）を防ぎます。  
また、GitHub Actions → AWS を OIDC 経由で認証する IAM ロールも追加しました。  

## 変更点
- .github/workflows/ci.yml
  - PRで terraform fmt/validate/plan を実行
  - plan.out/plan.txt を Artifact として保存
  - plan 要約を PR コメントに投稿
- .github/workflows/apply-dev.yml
  - main マージ時に dev 環境へ terraform apply（Environment "dev" 承認必須）
- environments/dev/iam_github_oidc.tf, variables.gh_oidc.tf
  - GitHub OIDC provider, IAM Role, Policy を IaC 化
- environments/dev/versions.tf
  - helm provider を =2.13.x に固定（kubernetes{} ブロック利用のため）
- environments/dev/.terraform.lock.hcl
  - provider ロックを更新